### PR TITLE
Create a separate Package definition for swift-tools 4 and Swift 4.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,9 +3,9 @@ import PackageDescription
 let package = Package(
     name: "AWS",
     targets: [
-        Target(name: "AWS", dependencies: ["AutoScaling", "EC2", "S3", "AWSSignatureV4"]),
-        Target(name: "EC2", dependencies: ["AWSSignatureV4"]),
+        Target(name: "AWS", dependencies: ["AutoScaling", "EC2", "S3"]),
         Target(name: "AutoScaling", dependencies: ["AWSSignatureV4"]),
+        Target(name: "EC2", dependencies: ["AWSSignatureV4"]),
         Target(name: "S3", dependencies: ["AWSSignatureV4"]),
         Target(name: "VaporS3", dependencies: ["S3"]),
     ],

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:4.0
+
+import PackageDescription
+
+let package = Package(
+    name: "AWS",
+    products: [
+        .library(name: "AWS", targets: ["AWS"]),
+        .library(name: "VaporS3", targets: ["VaporS3"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/vapor/vapor.git", from: "2.2.0"),
+        .package(url: "https://github.com/drmohundro/SWXMLHash", from: "4.1.1"),
+    ],
+    targets: [
+        .target(name: "AWS", dependencies: ["AutoScaling", "EC2", "S3"]),
+        .target(name: "AutoScaling", dependencies: ["AWSSignatureV4", "SWXMLHash"]),
+        .target(name: "AWSSignatureV4", dependencies: ["Vapor"]),
+        .target(name: "EC2", dependencies: ["AWSSignatureV4"]),
+        .target(name: "S3", dependencies: ["AWSSignatureV4"]),
+        .target(name: "VaporS3", dependencies: ["S3"]),
+        .testTarget(name: "AWSTests", dependencies: ["AWS"]),
+    ]
+)


### PR DESCRIPTION
Props to the SwiftPM team [for the solid docs](https://github.com/apple/swift-package-manager/blob/swift-4.0-branch/Documentation/PackageDescriptionV4.md).

Although it [looks like Travis supports Xcode 9.0](https://docs.travis-ci.com/user/languages/objective-c/) I couldn't quite nail down how to run across multiple macOS versions.