### PR TITLE
Add Driver for requests and support EC2 Instance Profile

### DIFF
--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     targets: [
         .target(name: "AWS", dependencies: ["AutoScaling", "EC2", "S3"]),
-        .target(name: "AutoScaling", dependencies: ["AWSSignatureV4", "SWXMLHash"]),
+        .target(name: "AutoScaling", dependencies: ["AWSSignatureV4", "SWXMLHash", "AWSDriver"]),
         .target(name: "AWSDriver", dependencies: ["Vapor", "AWSSignatureV4",]),
         .target(name: "AWSSignatureV4", dependencies: ["Vapor"]),
         .target(name: "EC2", dependencies: ["AWSDriver"]),

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -7,7 +7,6 @@ let package = Package(
     products: [
         .library(name: "AWS", targets: ["AWS"]),
         .library(name: "VaporS3", targets: ["VaporS3"]),
-        .executable(name: "swapper", targets: ["AWS", "AWSDriver"]),
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "2.2.0"),

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -7,6 +7,7 @@ let package = Package(
     products: [
         .library(name: "AWS", targets: ["AWS"]),
         .library(name: "VaporS3", targets: ["VaporS3"]),
+        .executable(name: "swapper", targets: ["AWS", "AWSDriver"]),
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "2.2.0"),
@@ -15,8 +16,9 @@ let package = Package(
     targets: [
         .target(name: "AWS", dependencies: ["AutoScaling", "EC2", "S3"]),
         .target(name: "AutoScaling", dependencies: ["AWSSignatureV4", "SWXMLHash"]),
+        .target(name: "AWSDriver", dependencies: ["Vapor", "AWSSignatureV4",]),
         .target(name: "AWSSignatureV4", dependencies: ["Vapor"]),
-        .target(name: "EC2", dependencies: ["AWSSignatureV4"]),
+        .target(name: "EC2", dependencies: ["AWSDriver"]),
         .target(name: "S3", dependencies: ["AWSSignatureV4"]),
         .target(name: "VaporS3", dependencies: ["S3"]),
         .testTarget(name: "AWSTests", dependencies: ["AWS"]),

--- a/Sources/AWSDriver/AWSDriver.swift
+++ b/Sources/AWSDriver/AWSDriver.swift
@@ -65,10 +65,8 @@ extension AWSDriver {
     func submitRequest(baseURL: String, query: String, method: HTTP.Method) throws -> String {
 
         let headers = try signer.sign(path: "/", query: query)
-        let client = try EngineClientFactory().makeClient(hostname: host, port: 443, securityLayer: .tls(Context.init(.client)), proxy: nil)
+        let client = try EngineClientFactory().makeClient(hostname: host, port: 443, securityLayer: .tls(Context(.client)), proxy: nil)
 
-        print("\(baseURL)/?\(query)")
-        print(headers)
         let version = HTTP.Version(major: 1, minor: 1)
         let request = HTTP.Request(method: Method.get, uri: "\(baseURL)/?\(query)", version: version, headers: headers, body: Body.data(Bytes([])))
         let response = try client.respond(to: request)

--- a/Sources/AWSDriver/AWSDriver.swift
+++ b/Sources/AWSDriver/AWSDriver.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+import AWSSignatureV4
+import Vapor
+import HTTP
+
+struct CredentialResponse: Codable {
+    enum Success: String, Codable {
+        case Success
+    }
+
+    let Code: Success
+    let LastUpdated: String
+    let awsType: String
+    let AccessKeyId: String
+    let SecretAccessKey: String
+    let Token: String
+    let Expiration: String
+
+    enum CodingKeys: String, CodingKey {
+        case Code, LastUpdated, AccessKeyId, SecretAccessKey, Token, Expiration
+        case awsType = "Type"
+    }
+}
+
+public enum Error: Swift.Error {
+    case roleError // Problem getting IAM role credentials
+}
+
+struct InstanceProfile {
+    func queryLocalEndpoint(urlPath: String) throws -> String {
+        let client = try EngineClientFactory.init().makeClient(hostname:
+            "169.254.169.254", port: 80, securityLayer: .none, proxy: nil)
+        let version = HTTP.Version(major: 1, minor: 1)
+        let request = HTTP.Request(method: Method.get, uri: urlPath, version: version, headers: [:], body: Body.data(Bytes([])))
+        let response = try client.respond(to: request)
+        guard let bytes = response.body.bytes else {
+            throw Error.roleError
+        }
+        return bytes.makeString()
+
+    }
+
+    func findInstanceRole() throws -> String {
+        return try queryLocalEndpoint(urlPath: "http://169.254.169.254/latest/meta-data/iam/security-credentials/")
+
+    }
+
+    func generateIAMCreds() throws -> (String, String) {
+        let role = try findInstanceRole()
+        let credString = try queryLocalEndpoint(urlPath: "http://169.254.169.254/latest/meta-data/iam/security-credentials/\(role)")
+        let decoder = JSONDecoder()
+        let credentials = try! decoder.decode(CredentialResponse.self, from: credString.data(using: .utf8)!)
+        return (credentials.AccessKeyId, credentials.SecretAccessKey)
+    }
+}
+
+public struct AWSDriver {
+    public let accessKey: String
+    public let secretKey: String
+
+    public init(accessKey: String? = nil, secretKey: String? = nil) throws {
+        if let access = accessKey, let secret = secretKey {
+            self.accessKey = access
+            self.secretKey = secret
+        } else {
+            (self.accessKey, self.secretKey) = try InstanceProfile().generateIAMCreds()
+        }
+    }
+}

--- a/Sources/AWSDriver/AWSDriver.swift
+++ b/Sources/AWSDriver/AWSDriver.swift
@@ -1,8 +1,7 @@
-import Foundation
-
 import AWSSignatureV4
-import Vapor
 import HTTP
+import TLS
+import Vapor
 
 struct CredentialResponse: Codable {
     enum Success: String, Codable {
@@ -23,47 +22,27 @@ struct CredentialResponse: Codable {
     }
 }
 
-public enum Error: Swift.Error {
-    case roleError // Problem getting IAM role credentials
-    case noRolesPresent // This host does not have an associated Instance profile
-}
-
-struct InstanceProfile {
-    func queryLocalEndpoint(urlPath: String) throws -> String {
-        let client = try EngineClientFactory.init().makeClient(hostname:
-            "169.254.169.254", port: 80, securityLayer: .none, proxy: nil)
-        let version = HTTP.Version(major: 1, minor: 1)
-        let request = HTTP.Request(method: Method.get, uri: urlPath, version: version, headers: [:], body: Body.data(Bytes([])))
-        let response = try client.respond(to: request)
-        guard let bytes = response.body.bytes else {
-            throw Error.roleError
-        }
-        return bytes.makeString()
-    }
-
-    func findInstanceRole() throws -> String {
-        let role = try queryLocalEndpoint(urlPath: "http://169.254.169.254/latest/meta-data/iam/security-credentials/")
-        if role.count < 1 {
-            throw Error.noRolesPresent
-        }
-        return role
-    }
-
-    func generateIAMCreds() throws -> (String, String, String?) {
-        let role = try findInstanceRole()
-        let credString = try queryLocalEndpoint(urlPath: "http://169.254.169.254/latest/meta-data/iam/security-credentials/\(role)")
-        let decoder = JSONDecoder()
-        let credentials = try! decoder.decode(CredentialResponse.self, from: credString.data(using: .utf8)!)
-        return (credentials.AccessKeyId, credentials.SecretAccessKey, credentials.Token)
-    }
-}
-
 public struct AWSDriver {
+    public enum Error: Swift.Error {
+        case invalidResponse(Status)
+    }
+
     public let accessKey: String
     public let secretKey: String
     public let token: String?
+    let service: String
+    let host: String
+    let signer: AWSSignatureV4
 
-    public init(accessKey: String? = nil, secretKey: String? = nil, token: String? = nil) throws {
+    public init(service: String, region: Region? = nil, accessKey: String? = nil, secretKey: String? = nil, token: String? = nil) throws {
+        self.service = service
+        var serviceRegion =  Region.usEast1
+        if let awsRegion = region {
+            self.host = "\(self.service).\(awsRegion.rawValue).amazonaws.com"
+            serviceRegion = awsRegion
+        } else {
+            self.host = "\(self.service).amazonaws.com"
+        }
         if let access = accessKey, let secret = secretKey {
             self.accessKey = access
             self.secretKey = secret
@@ -71,5 +50,50 @@ public struct AWSDriver {
         } else {
             (self.accessKey, self.secretKey, self.token) = try InstanceProfile().generateIAMCreds()
         }
+        self.signer = AWSSignatureV4(
+            service: self.service,
+            host: self.host,
+            region: serviceRegion,
+            accessKey: self.accessKey,
+            secretKey: self.secretKey,
+            token: self.token
+        )
+    }
+}
+
+extension AWSDriver {
+    func submitRequest(baseURL: String, query: String, method: HTTP.Method) throws -> String {
+
+        let headers = try signer.sign(path: "/", query: query)
+        let client = try EngineClientFactory().makeClient(hostname: host, port: 443, securityLayer: .tls(Context.init(.client)), proxy: nil)
+
+        print("\(baseURL)/?\(query)")
+        print(headers)
+        let version = HTTP.Version(major: 1, minor: 1)
+        let request = HTTP.Request(method: Method.get, uri: "\(baseURL)/?\(query)", version: version, headers: headers, body: Body.data(Bytes([])))
+        let response = try client.respond(to: request)
+
+        guard response.status == .ok else {
+            print("Response error: \(response)")
+            guard let bytes = response.body.bytes else {
+                throw Error.invalidResponse(response.status)
+            }
+
+            throw try ErrorParser.parse(bytes)
+        }
+
+        guard let bytes = response.body.bytes else {
+            throw Error.invalidResponse(.internalServerError)
+        }
+
+        return bytes.makeString()
+    }
+
+    public func get(baseURL: String, query: String) throws -> String {
+        return try submitRequest(baseURL: baseURL, query: query, method: .get)
+    }
+
+    public func post(baseURL: String, query: String) throws -> String {
+        return try submitRequest(baseURL: baseURL, query: query, method: .post)
     }
 }

--- a/Sources/AWSDriver/Driver.swift
+++ b/Sources/AWSDriver/Driver.swift
@@ -1,0 +1,8 @@
+public protocol Driver {
+    var accessKey: String { get }
+    var secretKey: String { get }
+    var token: String? { get }
+
+    func get(baseURL: String, query: String) throws -> String
+    func post(baseURL: String, query: String, body: String) throws -> String
+}

--- a/Sources/AWSDriver/InstanceProfile.swift
+++ b/Sources/AWSDriver/InstanceProfile.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+import HTTP
+import Vapor
+
+struct InstanceProfile {
+    public enum Error: Swift.Error {
+        case roleError // Problem getting IAM role credentials
+        case noRolesPresent // This host does not have an associated Instance profile
+    }
+
+    func queryLocalEndpoint(urlPath: String) throws -> String {
+        let client = try EngineClientFactory.init().makeClient(hostname:
+            "169.254.169.254", port: 80, securityLayer: .none, proxy: nil)
+        let version = HTTP.Version(major: 1, minor: 1)
+        let request = HTTP.Request(method: Method.get, uri: urlPath, version: version, headers: [:], body: Body.data(Bytes([])))
+        let response = try client.respond(to: request)
+        guard let bytes = response.body.bytes else {
+            throw Error.roleError
+        }
+        return bytes.makeString()
+    }
+
+    func findInstanceRole() throws -> String {
+        let role = try queryLocalEndpoint(urlPath: "http://169.254.169.254/latest/meta-data/iam/security-credentials/")
+        if role.count < 1 {
+            throw Error.noRolesPresent
+        }
+        return role
+    }
+
+    func generateIAMCreds() throws -> (String, String, String?) {
+        let role = try findInstanceRole()
+        let credString = try queryLocalEndpoint(urlPath: "http://169.254.169.254/latest/meta-data/iam/security-credentials/\(role)")
+        let decoder = JSONDecoder()
+        let credentials = try! decoder.decode(CredentialResponse.self, from: credString.data(using: .utf8)!)
+        return (credentials.AccessKeyId, credentials.SecretAccessKey, credentials.Token)
+    }
+}

--- a/Sources/AWSSignatureV4/AWSSignatureV4.swift
+++ b/Sources/AWSSignatureV4/AWSSignatureV4.swift
@@ -183,7 +183,7 @@ extension AWSSignatureV4 {
 
         var headers = headers
 
-        try generateHeadersToSign(headers: &headers, host: host, hash: payloadHash)
+        generateHeadersToSign(headers: &headers, host: host, hash: payloadHash)
 
         let sortedHeaders = alphabetize(headers)
         let signedHeaders = sortedHeaders.map { $0.key.lowercased() }.joined(separator: ";")

--- a/Sources/AWSSignatureV4/AWSSignatureV4.swift
+++ b/Sources/AWSSignatureV4/AWSSignatureV4.swift
@@ -26,6 +26,7 @@ public struct AWSSignatureV4 {
     let region: String
     let accessKey: String
     let secretKey: String
+    var token: String?
     let contentType = "application/x-www-form-urlencoded; charset=utf-8"
 
     internal var unitTestDate: Date?
@@ -42,13 +43,15 @@ public struct AWSSignatureV4 {
         host: String,
         region: Region,
         accessKey: String,
-        secretKey: String
+        secretKey: String,
+        token: String? = nil
     ) {
         self.service = service
         self.host = host
         self.region = region.rawValue
         self.accessKey = accessKey
         self.secretKey = secretKey
+        self.token = token
     }
 
     func getStringToSign(
@@ -124,6 +127,10 @@ extension AWSSignatureV4 {
         headers["Host"] = host
         headers["X-Amz-Date"] = amzDate
 
+        if let securityToken = token {
+            headers["X-Amz-Security-Token"] = securityToken
+        }
+
          if hash != "UNSIGNED-PAYLOAD" {
             headers["x-amz-content-sha256"] = hash
         }
@@ -176,7 +183,7 @@ extension AWSSignatureV4 {
 
         var headers = headers
 
-        generateHeadersToSign(headers: &headers, host: host, hash: payloadHash)
+        try generateHeadersToSign(headers: &headers, host: host, hash: payloadHash)
 
         let sortedHeaders = alphabetize(headers)
         let signedHeaders = sortedHeaders.map { $0.key.lowercased() }.joined(separator: ";")

--- a/Sources/AWSSignatureV4/ErrorParser/AWSError.swift
+++ b/Sources/AWSSignatureV4/ErrorParser/AWSError.swift
@@ -2,6 +2,7 @@ public enum AWSError: String {
     case accessDenied = "AccessDenied"
     case accountProblem = "AccountProblem"
     case ambiguousGrantByEmailAddress = "AmbiguousGrantByEmailAddress"
+    case authFailure = "AuthFailure"
     case authorizationHeaderMalformed = "AuthorizationHeaderMalformed"
     case badDigest = "BadDigest"
     case bucketAlreadyExists = "BucketAlreadyExists"

--- a/Sources/AWSSignatureV4/ErrorParser/ErrorParser+Grammar.swift
+++ b/Sources/AWSSignatureV4/ErrorParser/ErrorParser+Grammar.swift
@@ -7,6 +7,7 @@ extension ErrorParser {
         insert(into: trie, .accessDenied)
         insert(into: trie, .accountProblem)
         insert(into: trie, .ambiguousGrantByEmailAddress)
+        insert(into: trie, .authFailure)
         insert(into: trie, .authorizationHeaderMalformed)
         insert(into: trie, .badDigest)
         insert(into: trie, .bucketAlreadyExists)

--- a/Sources/AutoScaling/AutoScaling.swift
+++ b/Sources/AutoScaling/AutoScaling.swift
@@ -1,10 +1,8 @@
-import HTTP
 import Vapor
 import Core
 import Transport
-import AWSSignatureV4
 import AWSDriver
-import TLS
+import AWSSignatureV4
 import Node
 import SWXMLHash
 
@@ -31,34 +29,22 @@ public struct AutoScaling {
     public enum Error: Swift.Error {
         case InvalidNextToken // The NextToken value is not valid.
         case ResourceContention // You already have a pending update to an Auto Scaling resource (for example, a group, instance, or load balancer).
-        case invalidResponse(Status)
     }
 
-    let region: Region
     let service: String
     let host: String
     let baseURL: String
-    let signer: AWSSignatureV4
     let driver: AWSDriver
 
-    public init(region: Region, driver: AWSDriver? = nil) throws {
-        self.region = region
-        if driver == nil {
-            self.driver = try AWSDriver()
-        } else {
-            self.driver = driver!
-        }
+    public init(driver: AWSDriver? = nil) throws {
         self.service = "autoscaling"
         self.host = "\(self.service).amazonaws.com"
         self.baseURL = "https://\(self.host)"
-        self.signer = AWSSignatureV4(
-            service: self.service,
-            host: self.host,
-            region: self.region,
-            accessKey: self.driver.accessKey,
-            secretKey: self.driver.secretKey,
-            token: self.driver.token
-        )
+        if driver == nil {
+            self.driver = try AWSDriver(service: service)
+        } else {
+            self.driver = driver!
+        }
     }
 
     func generateQuery(for action: String, name: String) -> String {
@@ -70,29 +56,7 @@ public struct AutoScaling {
      */
     public func describeAutoScalingGroups(name: String) throws -> [Instance] {
         let query = generateQuery(for: "DescribeAutoScalingGroups", name: name)
-        let headers = try signer.sign(path: "/", query: query)
-        let client = try EngineClientFactory().makeClient(hostname: host, port: 443, securityLayer: .tls(Context.init(.client)), proxy: nil)
-
-        print("\(baseURL)/?\(query)")
-        print(headers)
-        let version = HTTP.Version(major: 1, minor: 1)
-        let request = HTTP.Request(method: Method.get, uri: "\(baseURL)/?\(query)", version: version, headers: headers, body: Body.data(Bytes([])))
-        let response = try client.respond(to: request)
-
-        guard response.status == .ok else {
-            print("Response error: \(response)")
-            guard let bytes = response.body.bytes else {
-                throw Error.invalidResponse(response.status)
-            }
-
-            throw try ErrorParser.parse(bytes)
-        }
-
-        guard let bytes = response.body.bytes else {
-            throw Error.invalidResponse(.internalServerError)
-        }
-
-        let output = bytes.makeString()
+        let output = try driver.get(baseURL: baseURL, query: query)
         let xml = SWXMLHash.parse(output)
         let autoscalingGroupXML = xml["DescribeAutoScalingGroupsResponse"]["DescribeAutoScalingGroupsResult"]["AutoScalingGroups"]["member"]
 

--- a/Sources/AutoScaling/AutoScaling.swift
+++ b/Sources/AutoScaling/AutoScaling.swift
@@ -31,17 +31,14 @@ public struct AutoScaling {
         case ResourceContention // You already have a pending update to an Auto Scaling resource (for example, a group, instance, or load balancer).
     }
 
-    let service: String
-    let host: String
-    let baseURL: String
-    let driver: AWSDriver
+    public static let service = "autoscaling"
+    static let host = "\(AutoScaling.service).amazonaws.com"
+    static let baseURL = "https://\(AutoScaling.host)"
+    let driver: Driver
 
-    public init(driver: AWSDriver? = nil) throws {
-        self.service = "autoscaling"
-        self.host = "\(self.service).amazonaws.com"
-        self.baseURL = "https://\(self.host)"
+    public init(driver: Driver? = nil) throws {
         if driver == nil {
-            self.driver = try AWSDriver(service: service)
+            self.driver = try AWSDriver(service: AutoScaling.service)
         } else {
             self.driver = driver!
         }
@@ -56,7 +53,7 @@ public struct AutoScaling {
      */
     public func describeAutoScalingGroups(name: String) throws -> [Instance] {
         let query = generateQuery(for: "DescribeAutoScalingGroups", name: name)
-        let output = try driver.get(baseURL: baseURL, query: query)
+        let output = try driver.get(baseURL: AutoScaling.baseURL, query: query)
         let xml = SWXMLHash.parse(output)
         let autoscalingGroupXML = xml["DescribeAutoScalingGroupsResponse"]["DescribeAutoScalingGroupsResult"]["AutoScalingGroups"]["member"]
 

--- a/Sources/EC2/EC2.swift
+++ b/Sources/EC2/EC2.swift
@@ -60,13 +60,8 @@ public class EC2 {
         )
     }
 
-    func generateQuery(for action: String, instanceId: String, securityGroup: String? = nil) -> String {
-        var query = "Action=\(action)&InstanceId=\(instanceId)"
-        if let sg = securityGroup {
-            query = "\(query)&GroupId.1=\(sg)"
-        }
-        query = "\(query)&Version=2016-11-15"
-        return query
+    func generateQuery(for action: String) -> String {
+        return "Action=\(action)"
     }
 
     /**
@@ -80,8 +75,15 @@ public class EC2 {
         - securityGroup: Security group to attach to this instance
     */
     public func modifyInstanceAttribute(instanceId: String, securityGroup: String? = nil) throws -> ModifyInstanceAttributeResponse? {
-        let query = generateQuery(for: "ModifyInstanceAttribute", instanceId: instanceId, securityGroup: securityGroup)
-        let output = try driver.post(baseURL: baseURL, query: query)
+        let query = generateQuery(for: "ModifyInstanceAttribute")
+
+        var body = "InstanceId=\(instanceId)&GroupId.1"
+        if let sg = securityGroup {
+            body = "\(body)&GroupId.1=\(sg)"
+        }
+        body = "\(body)&Version=2016-11-15"
+
+        let output = try driver.post(baseURL: baseURL, query: query, body: body)
 
         let xml = SWXMLHash.parse(output)
         let modifyResponse = xml["ModifyInstanceAttributeResponse"]

--- a/Sources/EC2/EC2.swift
+++ b/Sources/EC2/EC2.swift
@@ -1,23 +1,114 @@
 import Foundation
+import HTTP
+import TLS
+import SWXMLHash
+import AWSSignatureV4
+import AWSDriver
+import Vapor
 
-class EC2 {
-    let accessKey: String
-    let secretKey: String
-    let region: String
+public struct ModifyInstanceAttributeResponse {
+    public let requestId: String
+    public let returnValue: Bool
+}
+
+public enum ModifiableAttributes {
+    case instanceType
+    case kernel
+    case ramdisk
+    case userData
+    case disableApiTermination
+    case instanceInitiatedShutdownBehavior
+    case rootDeviceName
+    case blockDeviceMapping
+    case productCodes
+    case sourceDestCheck
+    case groupSet
+    case ebsOptimized
+    case sriovNetSupport
+    case enaSupport
+}
+
+public class EC2 {
+    public enum Error: Swift.Error {
+        case invalidResponse(Status)
+    }
+
+    let region: Region
     let service: String
     let host: String
     let baseURL: String
+    let signer: AWSSignatureV4
+    let driver: AWSDriver
 
-    public init(accessKey: String, secretKey: String, region: String) {
-        self.accessKey = accessKey
-        self.secretKey = secretKey
+    public init(region: Region, driver: AWSDriver? = nil) throws {
         self.region = region
         self.service = "ec2"
         self.host = "\(self.service).amazonaws.com"
         self.baseURL = "https://\(self.host)"
+        if driver == nil {
+            self.driver = try AWSDriver()
+        } else {
+            self.driver = driver!
+        }
+        self.signer = AWSSignatureV4(
+            service: self.service,
+            host: self.host,
+            region: self.region,
+            accessKey: self.driver.accessKey,
+            secretKey: self.driver.secretKey
+        )
     }
 
-    public func describeInstances() throws -> String {
+    func generateQuery(for action: String, instanceId: String) -> String {
+        return "Action=\(action)&InstanceID=\(instanceId)&Version=2016-11-15"
+    }
+
+    /**
+     Change the configuration of a running instance. Many attributes require the instance to be stopped before being changed. Please [see the docs for details](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyInstanceAttribute.html).
+
+     - returns:
+        Success or failure of the operation
+
+     - parameters:
+        - instanceID: Unique identifier of the form `i-<value>`
+    */
+    public func modifyInstanceAttribute(instanceId: String, securityGroup: String? = nil) throws -> ModifyInstanceAttributeResponse? {
+        var query = generateQuery(for: "ModifyInstanceAttribute", instanceId: instanceId)
+        if let sg = securityGroup {
+            query = "\(query)&GroupId.N=\(sg)"
+        }
+        print("\(baseURL)/?\(query)")
+        let headers = try signer.sign(path: "/", query: query)
+        let client = try EngineClientFactory.init().makeClient(hostname: host, port: 443, securityLayer: .tls(Context.init(.client)), proxy: nil)
+
+        let version = HTTP.Version(major: 1, minor: 1)
+        let request = HTTP.Request(method: Method.get, uri: "\(baseURL)/?\(query)", version: version, headers: headers, body: Body.data(Bytes([])))
+        let response = try client.respond(to: request)
+
+        guard response.status == .ok else {
+            print("Response error: \(response)")
+            guard let bytes = response.body.bytes else {
+                throw Error.invalidResponse(response.status)
+            }
+
+            throw try ErrorParser.parse(bytes)
+        }
+
+        guard let bytes = response.body.bytes else {
+            throw Error.invalidResponse(.internalServerError)
+        }
+
+        let output = bytes.makeString()
+        let xml = SWXMLHash.parse(output)
+        let modifyResponse = xml["ModifyInstanceAttributeResponse"]
+
+        if let requestId = modifyResponse["requestId"].element?.text, let returnStringValue = modifyResponse["return"].element?.text, let returnValue = Bool(returnStringValue) {
+            return ModifyInstanceAttributeResponse(requestId: requestId, returnValue: returnValue)
+        }
+        return nil
+    }
+
+    func describeInstances() throws -> String {
         //TODO(Brett): wrap this result in a model instead of a string type
         /*let response =  try AWSDriver().call(
             method: .get,

--- a/Sources/EC2/EC2.swift
+++ b/Sources/EC2/EC2.swift
@@ -6,7 +6,11 @@ import AWSSignatureV4
 import AWSDriver
 import Vapor
 
-public struct ModifyInstanceAttributeResponse {
+public struct ModifyInstanceAttributeResponse: Equatable {
+    public static func ==(lhs: ModifyInstanceAttributeResponse, rhs: ModifyInstanceAttributeResponse) -> Bool {
+        return lhs.requestId == rhs.requestId && lhs.returnValue == rhs.returnValue
+    }
+
     public let requestId: String
     public let returnValue: Bool
 }
@@ -38,17 +42,17 @@ public class EC2 {
     let host: String
     let baseURL: String
     let signer: AWSSignatureV4
-    let driver: AWSDriver
+    let driver: Driver
 
-    public init(region: Region, driver: AWSDriver? = nil) throws {
+    public init(region: Region, driver: Driver? = nil) throws {
         self.region = region
         self.service = "ec2"
         self.host = "\(self.service).\(region.rawValue).amazonaws.com"
         self.baseURL = "https://\(self.host)"
-        if driver == nil {
-            self.driver = try AWSDriver(service: service, region: region)
+        if let driver = driver {
+            self.driver = driver
         } else {
-            self.driver = driver!
+            self.driver = try AWSDriver(service: service, region: region)
         }
         self.signer = AWSSignatureV4(
             service: self.service,

--- a/Sources/EC2/EC2.swift
+++ b/Sources/EC2/EC2.swift
@@ -81,29 +81,8 @@ public class EC2 {
     */
     public func modifyInstanceAttribute(instanceId: String, securityGroup: String? = nil) throws -> ModifyInstanceAttributeResponse? {
         let query = generateQuery(for: "ModifyInstanceAttribute", instanceId: instanceId, securityGroup: securityGroup)
-        let headers = try signer.sign(method: .post, path: "/", query: query)
-        let client = try EngineClientFactory().makeClient(hostname: host, port: 443, securityLayer: .tls(Context.init(.client)), proxy: nil)
+        let output = try driver.post(baseURL: baseURL, query: query)
 
-        let version = HTTP.Version(major: 1, minor: 1)
-        print("\(baseURL)/?\(query)")
-        print(headers)
-        let request = HTTP.Request(method: Method.post, uri: "\(baseURL)/?\(query)", version: version, headers: headers, body: Body.data(Bytes([])))
-        let response = try client.respond(to: request)
-
-        guard response.status == .ok else {
-            print("Response error: \(response)")
-            guard let bytes = response.body.bytes else {
-                throw Error.invalidResponse(response.status)
-            }
-
-            throw try ErrorParser.parse(bytes)
-        }
-
-        guard let bytes = response.body.bytes else {
-            throw Error.invalidResponse(.internalServerError)
-        }
-
-        let output = bytes.makeString()
         let xml = SWXMLHash.parse(output)
         let modifyResponse = xml["ModifyInstanceAttributeResponse"]
 

--- a/Tests/AWSTests/AWSDriverTests.swift
+++ b/Tests/AWSTests/AWSDriverTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+
+import Foundation
+import Sockets
+import TLS
+import Vapor
+
+@testable import AWSDriver
+
+struct FakeClient: Responder {
+    init(hostname: String, port: Sockets.Port, securityLayer: SecurityLayer, proxy: Proxy?) throws {
+        return
+    }
+
+    init() throws {
+        try self.init(hostname: "fakehostname", port: 1337, securityLayer: SecurityLayer.tls(Context(.client)), proxy: nil)
+    }
+
+    func respond(to request: Request) throws -> Response {
+        return Response(status: .ok, body: "{}".makeBody())
+    }
+}
+
+class AWSDriverTests: XCTestCase {
+    static var allTests = [
+        ("testSubmitRequest", testSubmitRequest)
+    ]
+
+    func testSubmitRequest() throws {
+        let driver = try AWSDriver(service: "fakeservice", region: .usEast1, accessKey: "fake-access", secretKey: "fake-secret", token: "fake-token", client: FakeClient())
+        let response = try driver.submitRequest(baseURL: "baseURL.com", query: "query:fake", method: .get)
+        XCTAssertEqual(response, "{}")
+    }
+}

--- a/Tests/AWSTests/AutoscalingTests.swift
+++ b/Tests/AWSTests/AutoscalingTests.swift
@@ -4,14 +4,16 @@ import HTTP
 import Foundation
 
 @testable import AutoScaling
+import AWSDriver
 
 class AutoscalingTests: XCTestCase {
     static var allTests = [
         ("testGenerateQuery", testGenerateQuery)
     ]
 
-    func testGenerateQuery() {
-        let autoscaling = AutoScaling(accessKey: "fake", secretKey: "secret", region: "us-east-1")
+    func testGenerateQuery() throws {
+        let driver = try AWSDriver(service: AutoScaling.service, region: .usEast1, accessKey: "fake-access", secretKey: "fake-secret", token: "fake-token")
+        let autoscaling = try AutoScaling(driver: driver)
         let query = autoscaling.generateQuery(for: "Action", name: "autoscaling-name")
         XCTAssertEqual(query, "Action=Action&AutoScalingGroupNames.member.1=autoscaling-name&Version=2011-01-01")
     }

--- a/Tests/AWSTests/EC2Tests.swift
+++ b/Tests/AWSTests/EC2Tests.swift
@@ -1,0 +1,34 @@
+import XCTest
+
+import AWSDriver
+
+@testable import EC2
+
+struct FakeDriver: Driver {
+    var accessKey: String
+    var secretKey: String
+    var token: String?
+
+    func get(baseURL: String, query: String) throws -> String {
+        return "get"
+    }
+
+    func post(baseURL: String, query: String, body: String) throws -> String {
+        return "<ModifyInstanceAttributeResponse xmlns=\"http://ec2.amazonaws.com/doc/2016-11-15/\"><requestId>9001</requestId><return>true</return></ModifyInstanceAttributeResponse>"
+    }
+}
+
+class EC2Tests: XCTestCase {
+    static var allTests = [
+        ("testModifyInstanceAttribute", testModifyInstanceAttribute)
+    ]
+
+    func testModifyInstanceAttribute() throws {
+        let driver = FakeDriver(accessKey: "fake-access", secretKey: "fake-secret", token: "fake-token")
+        let fakeResponse = ModifyInstanceAttributeResponse(requestId: "9001", returnValue: true)
+
+        let client = try EC2(region: .usEast1, driver: driver)
+        let response = try client.modifyInstanceAttribute(instanceId: "i-9001", securityGroup: "very-secure")
+        XCTAssertEqual(response, fakeResponse)
+    }
+}


### PR DESCRIPTION
This PR adds three features (so happy to split up if easier to review):

1. An `AWSDriver` to handle connection logic. This removes a lot of extra boilerplate, and I think something like this used to exist in the git history.
2. Support for AWS [Instance Profiles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) on EC2 instances. This allows this library to be used on an EC2 with a specific IAM role (a best practice), and no longer ties this library to only being used by API credentials.
3. An `EC2` class, the first method changes the security groups associated with an EC2 instance.

Longer term.. it's likely a better idea we go the route of the AWS-supported libraries and generate the code, but in the meantime, this is likely good enough. Open to ideas though!